### PR TITLE
fix #11518: update Insight UI context menu tests (rebased)

### DIFF
--- a/components/tests/ui/testcases/insight/menus/context-menus.txt
+++ b/components/tests/ui/testcases/insight/menus/context-menus.txt
@@ -12,17 +12,18 @@ Resource  ../../../resources/insight/state.txt
 
 Enabled Menu Items
         [Documentation]                         check that context menu items are correctly enabled or disabled
-        ${import text}=                         Get Java String     agents.treeviewer.actions.ImportAction.NAME
+        ${import text}=                         Get Java String            agents.treeviewer.actions.ImportAction.NAME
         Select Window                           tree viewer window
         Expand Browser                          project
-        Tree Node Should Be Visible             project tree        ${FULL NAME}|Orphaned Images
-        Tree Node Menu Item Should Be Enabled   Open with           ${FULL NAME}                  project tree
-        Tree Node Menu Item Should Be Enabled   ${import text}      ${FULL NAME}                  project tree
-        Tree Node Menu Item Should Be Disabled  New...              ${FULL NAME}                  project tree
-        Tree Node Menu Item Should Be Enabled   Refresh User        ${FULL NAME}                  project tree
-        Expand Tree Node                        project tree        ${FULL NAME}
-        Tree Node Should Be Visible             project tree        ${FULL NAME}|Orphaned Images
-        Tree Node Menu Item Should Be Enabled   Open with           ${FULL NAME}|Orphaned Images  project tree
-        Tree Node Menu Item Should Be Disabled  ${import text}      ${FULL NAME}|Orphaned Images  project tree
-        Tree Node Menu Item Should Be Disabled  New...              ${FULL NAME}|Orphaned Images  project tree
-        Tree Node Menu Item Should Be Disabled  Refresh User        ${FULL NAME}|Orphaned Images  project tree
+        Tree Node Menu Item Should Be Enabled   Open with                  ${FULL NAME}                  project tree
+        Tree Node Menu Item Should Be Enabled   ${import text}             ${FULL NAME}                  project tree
+        Tree Node Menu Item Should Be Enabled   Create New|New Project...  ${FULL NAME}                  project tree
+        Tree Node Menu Item Should Be Enabled   Create New|New Dataset...  ${FULL NAME}                  project tree
+        Tree Node Menu Item Should Be Enabled   Refresh User               ${FULL NAME}                  project tree
+        Expand Tree Node                        project tree               ${FULL NAME}
+        Tree Node Should Be Visible             project tree               ${FULL NAME}|Orphaned Images
+        Tree Node Menu Item Should Be Enabled   Open with                  ${FULL NAME}|Orphaned Images  project tree
+        Tree Node Menu Item Should Be Disabled  ${import text}             ${FULL NAME}|Orphaned Images  project tree
+        Tree Node Menu Item Should Be Disabled  Create New|New Project...  ${FULL NAME}|Orphaned Images  project tree
+        Tree Node Menu Item Should Be Disabled  Create New|New Dataset...  ${FULL NAME}|Orphaned Images  project tree
+        Tree Node Menu Item Should Be Disabled  Refresh User               ${FULL NAME}|Orphaned Images  project tree


### PR DESCRIPTION
Insight's UI changed and the context menu tests had to change accordingly. This required extension of functionality so that the relevant keywords could work down into submenus.

This PR fixes https://trac.openmicroscopy.org.uk/ome/ticket/11518 and rebases https://github.com/openmicroscopy/openmicroscopy/pull/1606 to make `./build.py -f components/tests/ui/build.xml ui-test-insight -DTEST=menus` pass after https://github.com/openmicroscopy/openmicroscopy/pull/1503 is merged into an up-to-date `develop`.

In general, the tests seem to pass far more reliably locally than on Hudson.
