### PR TITLE
Add logic to set the QA baseurl via the command line importer

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -118,6 +118,7 @@ public class ImportConfig {
     public final BoolValue sendReport;
     public final BoolValue sendFiles;
     public final BoolValue sendLogFile;
+    public final StrValue qaBaseURL;
 
     public final BoolValue useCustomImageNaming;
     public final BoolValue useFullPath;
@@ -133,6 +134,7 @@ public class ImportConfig {
     public final AnnotationListValue annotations;
     public final DoubleArrayValue userPixels;
 
+    public final static String DEFAULT_QABASEURL = "http://qa.openmicroscopy.org.uk/qa";
     /**
      * Keys for fileset version information entries.
      * @author m.t.b.carroll@dundee.ac.uk
@@ -243,6 +245,7 @@ public class ImportConfig {
         group		 = new LongValue("group", this, null);
         doThumbnails = new BoolValue("doThumbnails", this, true);
         email        = new StrValue("email", this);
+        qaBaseURL    = new StrValue("qaBaseURL", this, DEFAULT_QABASEURL);
         userSpecifiedName = new StrValue("userSpecifiedName", this);
         userSpecifiedDescription = new StrValue("userSpecifiedDescription", this);
         targetClass  = new StrValue("targetClass", this);
@@ -516,24 +519,24 @@ public class ImportConfig {
     }
 
     /**
-     * @return ini feedback URL for QA system
+     * @return feedback URL for QA system
      */
     public String getFeedbackUrl() {
-        return ini.getUploaderURL();
+        return qaBaseURL + "/upload_processing/";
     }
 
     /**
-     * @return ini token URL for QA system
+     * @return token URL for QA system
      */
     public String getTokenUrl() {
-        return ini.getUploaderTokenURL();
+        return qaBaseURL + "/initial/";
     }
 
     /**
-     * @return ini upload URL for QA system
+     * @return upload URL for QA system
      */
     public String getUploaderUrl() {
-        return ini.getUploaderURL();
+        return qaBaseURL + "/upload_processing/";
     }
 
     /**

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -370,6 +370,12 @@ public class CommandLineImporter {
             + "  e.g. $ bin/omero import -- --checksum_algorithm=CRC-32 foo.tiff\n"
             + "       $ ./importer-cli --checksum_algorithm=Murmur3-128 bar.tiff\n"
             + "\n"
+            + "  Feedback:\n"
+            + "  ---------\n\n"
+            + "    --qa_baseurl=ARG\tSpecify the base URL for reporting feedback\n"
+            + "  e.g. $ bin/omero import -- --qa_baseurl=https://qa.staging.openmicroscopy.org/qa\n"
+            + "       $ ./importer-cli --qa_baseurl=https://qa.staging.openmicroscopy.org/qa\n"
+            + "\n"
             + "Report bugs to <ome-users@lists.openmicroscopy.org.uk>");
         System.exit(1);
     }
@@ -473,20 +479,23 @@ public class CommandLineImporter {
         LongOpt autoClose =
                 new LongOpt("auto_close", LongOpt.NO_ARGUMENT, null, 19);
 
+        LongOpt qaBaseURL = new LongOpt(
+                "qa_baseurl", LongOpt.REQUIRED_ARGUMENT, null, 20);
+
         // DEPRECATED OPTIONS
         LongOpt plateName = new LongOpt(
-                "plate_name", LongOpt.REQUIRED_ARGUMENT, null, 20);
+                "plate_name", LongOpt.REQUIRED_ARGUMENT, null, 21);
         LongOpt plateDescription = new LongOpt(
-                "plate_description", LongOpt.REQUIRED_ARGUMENT, null, 21);
+                "plate_description", LongOpt.REQUIRED_ARGUMENT, null, 22);
 
         Getopt g = new Getopt(APP_NAME, args, "cfl:s:u:w:d:r:k:x:n:p:h",
                 new LongOpt[] { debug, report, upload, logs, email,
                                 name, description, noThumbnails,
                                 agent, annotationNamespace, annotationText,
                                 annotationLink, transferOpt, advancedHelp,
-                                checksumAlgorithm, minutesWait, closeCompleted,
-                                waitCompleted, autoClose,
-                                plateName, plateDescription});
+                                checksumAlgorithm, minutesWait,
+                                closeCompleted, waitCompleted, autoClose,
+                                qaBaseURL, plateName, plateDescription});
         int a;
 
         boolean doCloseCompleted = false;
@@ -596,9 +605,13 @@ public class CommandLineImporter {
                 config.autoClose.set(true);
                 break;
             }
+            case 20: {
+                config.qaBaseURL.set(g.getOptarg());
+                break;
+            }
             // ADVANCED END ---------------------------------------------------
             // DEPRECATED OPTIONS
-            case 20: {
+            case 21: {
                 if (userSpecifiedNameAlreadySet) {
                     usage();
                 }
@@ -606,7 +619,7 @@ public class CommandLineImporter {
                 userSpecifiedNameAlreadySet = true;
                 break;
             }
-            case 21: {
+            case 22: {
                 if (userSpecifiedDescriptionAlreadySet) {
                     usage();
                 }

--- a/components/blitz/src/ome/formats/importer/util/IniFileLoader.java
+++ b/components/blitz/src/ome/formats/importer/util/IniFileLoader.java
@@ -451,33 +451,6 @@ public class IniFileLoader {
     }
 
     /**
-     * @return uploader token URL for QA
-     */
-    public String getUploaderTokenURL()
-    {
-        return staticPref("Uploader", "TokenURL",
-                "https://qa.staging.openmicroscopy.org/qa/initial/");
-    }
-
-    /**
-     * @return uploader URL for QA
-     */
-    public String getUploaderURL()
-    {
-        return staticPref("Uploader", "URL",
-                "https://qa.staging.openmicroscopy.org/qa/upload_processing/");
-    }
-
-    /**
-     * @return bug tracker URL for QA
-     */
-    public String getBugTrackerURL()
-    {
-        return staticPref("Uploader", "BugTrackerURL",
-                "https://qa.staging.openmicroscopy.org/qa/upload_processing/");
-    }
-
-    /**
      * @return Returns the userSettingsDirectory.
      */
     public String getUserSettingsDirectory()

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -104,7 +104,7 @@ class ImportControl(BaseControl):
             metavar="DESCRIPTION")
 
         # Feedback options
-        feedback_group =  parser.add_argument_group(
+        feedback_group = parser.add_argument_group(
             'Feedback arguments',
             'Optional arguments passed strictly to Java allowing to report'
             ' errors to the OME team.')

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -103,6 +103,27 @@ class ImportControl(BaseControl):
             help="Image or plate description to use (**)",
             metavar="DESCRIPTION")
 
+        # Feedback options
+        feedback_group =  parser.add_argument_group(
+            'Feedback arguments',
+            'Optional arguments passed strictly to Java allowing to report'
+            ' errors to the OME team.')
+        feedback_group.add_argument(
+            "--report", action="store_true", dest="java_report",
+            help="Report errors to the OME team (**)")
+        feedback_group.add_argument(
+            "--upload", action="store_true", dest="java_upload",
+            help="Upload broken files with report (**)")
+        feedback_group.add_argument(
+            "--logs", action="store_true", dest="java_logs",
+            help="Upload log file with report (**)")
+        feedback_group.add_argument(
+            "--email", dest="java_email",
+            help="Email for reported errors (**)", metavar="EMAIL")
+        feedback_group.add_argument(
+            "--qa_baseurl", dest="java_qa_baseurl",
+            help=SUPPRESS)
+
         # DEPRECATED OPTIONS
         deprecated_name_group = parser.add_argument_group()
         deprecated_name_group.add_argument(
@@ -132,18 +153,6 @@ class ImportControl(BaseControl):
             "-r", dest="java_r",
             help="OMERO screen ID to import plate into (**)",
             metavar="SCREEN_ID")
-        java_group.add_argument(
-            "--report", action="store_true", dest="java_report",
-            help="Report errors to the OME team (**)")
-        java_group.add_argument(
-            "--upload", action="store_true", dest="java_upload",
-            help="Upload broken files with report (**)")
-        java_group.add_argument(
-            "--logs", action="store_true", dest="java_logs",
-            help="Upload log file with report (**)")
-        java_group.add_argument(
-            "--email", dest="java_email",
-            help="Email for reported errors (**)", metavar="EMAIL")
         java_group.add_argument(
             "--debug", dest="java_debug",
             help="Turn debug logging on (**)",
@@ -226,11 +235,12 @@ class ImportControl(BaseControl):
             "java_description": ("--description",),
             "java_plate_name": ("--plate_name",),
             "java_plate_description": ("--plate_description",),
-            "java_report": "--report",
-            "java_upload": "--upload",
-            "java_logs": "--logs",
-            "java_email": "--email",
+            "java_report": ("--report"),
+            "java_upload": ("--upload"),
+            "java_logs": ("--logs"),
+            "java_email": ("--email"),
             "java_debug": ("--debug",),
+            "java_qa_baseurl": ("--qa_baseurl",),
             "java_ns": "--annotation_ns",
             "java_text": "--annotation_text",
             "java_link": "--annotation_link",


### PR DESCRIPTION
- Deprecate usage of `IniFileLoader` in favor of `ImportConfig` to store the feedback URL
- Allow the baseURL to be set for a given `ImportConfig`
- Expose a `--qa_baseurl` argument in the command-line importer (Java & Python)
- Group the feedback arguments in the CLI import plugin

e.g.

```
bin/omero import test\&physicalSizeX\=-1.fake --report --upload --logs --email s.besson@dundee.ac.uk --qa_baseurl https://qa.staging.openmicroscopy.org/qa
```
