### PR TITLE
Fix no data error

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -870,15 +870,12 @@ class ImporterComponent
 			}
 		}
 		model.saveROI(component, ids);
-		if (l.size() > 0) {
-		    if (PlateData.class.equals(klass)) l = l.subList(0, 0);
-		    else {
-		        if (l.size() > FileImportComponent.MAX_THUMBNAILS) {
-		            l = l.subList(0, FileImportComponent.MAX_THUMBNAILS); 
-		        }
-		    }
-		    model.fireImportResultLoading(l, klass, component);
-		}
+        if (l.size() > 0 && !PlateData.class.equals(klass)) {
+            if (l.size() > FileImportComponent.MAX_THUMBNAILS) {
+                l = l.subList(0, FileImportComponent.MAX_THUMBNAILS);
+            }
+            model.fireImportResultLoading(l, klass, component);
+        }
 	}
 
 	/** 


### PR DESCRIPTION
I guess the intention for line `if (PlateData.class.equals(klass)) l = l.subList(0, 0);` was to not load anything in case of PlateData, so I modified the code that in this case `model.fireImportResultLoading()` isn't called at all, which prevents the 'no data to load' error being thrown.
