### PR TITLE
Reinclude com.google.code.findbugs to fix subethasmtp Javadoc warnings

### DIFF
--- a/components/server/ivy.xml
+++ b/components/server/ivy.xml
@@ -46,7 +46,6 @@
     <dependency org="xml-apis" name="xml-apis-ext" rev="${versions.xml-apis}"/>
     <dependency org="org.subethamail" name="subethasmtp" rev="${versions.subethasmtp}">
         <exclude org="org.slf4j"/>
-        <exclude org="com.google.code.findbugs"/>
     </dependency>
     <dependency org="pdfbox" name="pdfbox" rev="${versions.pdfbox}"/>
     <dependency org="edu.ucar" name="grib" rev="${versions.grib}" transitive="false"/>


### PR DESCRIPTION
This should reinclude the `jsr305` dependency of `subethasmtp` and remove the remaining Javadoc warnings when running

```
./build.py -f components/server/build.xml
```
