### PR TITLE
update graph policy rules for change in spatialDomainEnhancement

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -497,15 +497,15 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].projections = PD:[E]" p:changes="PD:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].quantization = Q:[E]" p:changes="Q:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].waveRendering = CB:[E]" p:changes="CB:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
 
         <!-- If rendering settings are moved then move the subgraph below. -->
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- Regardless of permissions move thumbnails, except to a private group delete them if another's. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -163,8 +163,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].projections = PD:[E]" p:changes="PD:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].quantization = Q:[E]" p:changes="Q:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].waveRendering = CB:[E]" p:changes="CB:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -523,8 +523,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- Give thumbnails only in a private group. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
@@ -193,8 +193,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
@@ -191,8 +191,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].projections = [I]" p:changes="RD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].quantization = [I]" p:changes="RD:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].spatialDomainEnhancement = [I]" p:changes="RD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RD:RenderingDef[E].waveRendering = [I]" p:changes="RD:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="CB:ChannelBinding[E].spatialDomainEnhancement = [I]" p:changes="CB:[I]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -379,8 +379,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].projections = PD:[E]" p:changes="PD:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].quantization = Q:[E]" p:changes="Q:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[D].waveRendering = CB:[E]" p:changes="CB:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[D].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[D]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
@@ -193,8 +193,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- EXPERIMENT -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
@@ -302,8 +302,8 @@
 
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].projections = PD:[E]" p:changes="PD:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].quantization = Q:[E]" p:changes="Q:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="RenderingDef[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
         <bean parent="graphPolicyRule" p:matches="RenderingDef[I].waveRendering = CB:[E]" p:changes="CB:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="ChannelBinding[I].spatialDomainEnhancement = SDE:[E]" p:changes="SDE:[I]"/>
 
         <!-- We cannot yet duplicate thumbnails. -->
 


### PR DESCRIPTION
`spatialDomainEnhancement` moved from `RenderingDef` to `ChannelBinding`

With this PR:

```
$ omero chgrp read-only-1 Image:22301 --report
Using session 23034cbd-ce6e-4307-9a2a-e55f01c349b2 (user-2@localhost:4064). Idle timeout: 10 min. Current group: private-1
omero.cmd.Chgrp2 Image:22301 ok
Steps: 6
Elapsed time: 0.629 secs.
Flags: []
Included objects
  Channel:22301
  Image:22301
  LogicalChannel:51
  OriginalFile:768,769
  Pixels:22301
  ChannelBinding:21801
  QuantumDef:21801
  RenderingDef:21801
  ReverseIntensityContext:1
  Thumbnail:21801
  Fileset:51
  FilesetEntry:51
  FilesetJobLink:101-105
  IndexingJob:770
  JobOriginalFileLink:731
  MetadataImportJob:767
  PixelDataJob:768
  ThumbnailGenerationJob:769
  UploadJob:766
  StatsInfo:21761
```
