### PR TITLE
Fix render tests

### DIFF
--- a/components/tests/python/library/__init__.py
+++ b/components/tests/python/library/__init__.py
@@ -369,12 +369,13 @@ class ITest(object):
         self, client=None,
         plates=1, plateAcqs=1,
         plateCols=1, plateRows=1,
-        fields=1, **kwargs
+        fields=1, screens=0, **kwargs
     ):
 
         if client is None:
             client = self.client
 
+        kwargs["screens"] = screens
         kwargs["plates"] = plates
         kwargs["plateAcqs"] = plateAcqs
         kwargs["plateCols"] = plateCols

--- a/components/tools/OmeroPy/test/integration/clitest/test_render.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_render.py
@@ -47,7 +47,7 @@ class TestRender(CLITest):
     def create_image(self, sizec=4):
         self.gw = BlitzGateway(client_obj=self.client)
         self.plates = []
-        for plate in self.importPlates(fields=2, sizeC=sizec):
+        for plate in self.importPlates(fields=2, sizeC=sizec, screens=1):
             self.plates.append(self.gw.getObject("Plate", plate.id.val))
         # Now pick the first Image
         self.imgobj = list(self.plates[0].listChildren())[0].getImage(index=0)


### PR DESCRIPTION
This should fix most of the failing tests on https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-python/379/testReport/ and the equivalent Python27 build. This reflects a change in the way fake plates are created where a screen is no longer created by default.

The first commit is sufficient to fix the tests, the second is a bit more proper in self-documenting the behaviour.
