### PR TITLE
Fix link to Search scenario on ome-internal

### DIFF
--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation     Tests Search on Web
-...               https://www.openmicroscopy.org/private/ome-internal/testing_scenarios/Search.html
+...               https://docs.openmicroscopy.org/internal/testing_scenarios/Search.html
 
 Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt


### PR DESCRIPTION
# What this PR does

Fixes the link to ome-internal which does not work for working link.

To test, check the  changed link works.


