### PR TITLE
Improve robot ratings tests

### DIFF
--- a/components/tests/ui/testcases/web/annotate_test.txt
+++ b/components/tests/ui/testcases/web/annotate_test.txt
@@ -46,7 +46,9 @@ Filter Rating
 
 Check For Rating
     [Arguments]                                 ${rating}
-    Wait Until Element Is Visible               xpath=//img[@title='Click to add rating'][contains(@src, 'rating${rating}')]
+    ${src}=                                     Get Element Attribute   xpath=//img[@title='Click to add rating']   attribute=src
+    Should Contain                              ${src}                  rating${rating}
+
 
 Count Thumbs With Class
     # Check that the number of thumbnails with this class is the expected number
@@ -133,7 +135,8 @@ Test Delete Rating
     Select And Expand Node                      Dataset 1
     ${imageId}=                                 Select First Image
     ${nodeId}=                                  Wait For Image Node         ${imageId}
-    Click Element                               xpath=//h1[@data-name='ratings']
+    # Try to open Ratings pane if closed
+    Run Keyword And Ignore Error                Click Element  xpath=//h1[@data-name='ratings'][contains(@class, 'closed')]
 
     # Select second image
     Click Next Thumbnail


### PR DESCRIPTION
# What this PR does

This fixes ratings robot tests locally for me. No more ```StaleElementReferenceException``` etc,

```./build.py -f components/tests/ui/build.xml web-browser -DTEST=annotate_test.txt```

All passing on Firefox and Chrome.